### PR TITLE
Pin actions to commit SHAs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,4 +28,4 @@ jobs:
       - run: go test ./... -v -cover -coverprofile coverage.out
       - run: go test -bench . -benchmem
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,8 +18,8 @@ jobs:
         go: ["1.16", "1.17", "1.18", "1.19"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-go@be3c94b385c46ce66fc01faa1b4db15cdae82f79 # v3
         with:
           go-version: ${{ matrix.go }}
 


### PR DESCRIPTION
## Summary
- Pin remaining unpinned action references to immutable commit SHAs for supply-chain security.

### Actions pinned
- `actions/checkout@v3` -> `f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `actions/setup-go@v3` -> `be3c94b385c46ce66fc01faa1b4db15cdae82f79`

### Intentionally left unpinned
- `codecov/codecov-action@v2` -- very old version; skipping SHA pin for now.