### PR TITLE
Fix incorrect SHA for actions/setup-go@v3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-      - uses: actions/setup-go@be3c94b385c46ce66fc01faa1b4db15cdae82f79 # v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ matrix.go }}
 


### PR DESCRIPTION
## Summary
- Fix invalid SHA for `actions/setup-go@v3` that was causing CI failures
- `be3c94b385c46ce66fc01faa1b4db15cdae82f79` → `be3c94b385c4f180051c996d336f57a34c397495`